### PR TITLE
Configure TCP or UNIX socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,34 @@
 ---
-language: python
-python: "2.7"
+# Based on: 
+#   https://blog.travis-ci.com/2017-11-30-testing-ansible-roles-using-docker-on-travis
+#   https://github.com/drhelius/travis-ansible-demo
 
-# Use the new container infrastructure
-sudo: false
+sudo: required
 
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+env:
+  - distribution: centos
+    version: 7
+  - distribution: ubuntu
+    version: xenial
+  - distribution: ubuntu
+    version: trusty
 
-install:
-  # Install ansible
-  - pip install ansible
+services:
+  - docker
 
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+before_install:
+  - 'sudo docker pull ${distribution}:${version}'
+  - 'sudo docker build --no-cache --rm --file=travis/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible travis'
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
-
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  - container_id=$(mktemp)
+  - 'sudo docker run --detach --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --volume="${PWD}":/etc/ansible/roles/clamav_role:ro ${distribution}-${version}:ansible > "${container_id}"'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/clamav_role/travis/test.yml --syntax-check'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/clamav_role/travis/test.yml'
+  ## skipping idempotence tests for now
+  # - >
+  #   sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/clamav_role/travis/test.yml
+  #   | grep -q 'changed=0.*failed=0'
+  #   && (echo 'Idempotence test: pass' && exit 0)
+  #   || (echo 'Idempotence test: fail' && exit 1)
+  - 'sudo docker rm -f "$(cat ${container_id})"'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,30 @@ ansible-clamav
 
 Installs clamav (daemon and client). 
 
+Role Variables
+______________
+
+- `CLAMAV_SOCKET_TYPE`: The clamd daemon listens for incoming connections on
+  Unix and/or TCP socket and scans files or directories on demand. This role
+allows the clamd daemon to be configured with UNIX socket ("file") or TCP
+socket ("tcp"). The default value is "file".
+- `CLAMAV_MAX_FILE_SIZE`: Clamscan extracts and scans at most this number of
+  kilobytes from each archive. You may pass the value in megabytes in format xM
+or xm, where x is a number. This option protects your system against DoS
+attacks (default: "2000M", max: <4GB)
+- `CLAMAV_MAX_SCAN_SIZE`: Clamscan extracts and scans at most this number of
+  kilobytes from each scanned file. You may pass the value in megabytes in
+format xM or xm, where x is a number. This option protects your system against
+DoS attacks (default: "2000M", max: <4G)
+- `CLAMAV_MAX_STREAM_LENGTH`: Clamd uses FTP-like protocol to receive data from
+  remote clients. This option allows you to specify the upper limit for data
+size that will be transfered to remote daemon when scanning a single file.
+(default: "2000M")
+
+- `CLAMAV_TCP_PORT`: TCP port number the clamd daemon will listen on. (default:
+  "3310")
+
+- `CLAMAV_TCP_ADDR`: TCP socket address to bind to. (default: "127.0.0.1")
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,15 @@ CLAMAV_MAX_FILE_SIZE: "2000M"
 CLAMAV_MAX_SCAN_SIZE: "2000M"
 CLAMAV_MAX_STREAM_LENGTH: "2000M"
 
+# The clamd can be configured to work with a file socket or a tcp socket.
+# Available Options for CLAMAV_SOCKET_TYPE are "tcp" and "file".
+# This env var has not a default value. 
+# - On CentOS the role will use "tcp" if not defined
+# - On Ubuntu the role will use "file" if not defined
+#CLAMAV_SOCKET_TYPE="file"
+
+# defaults tcp port and IP address to bind the TCP socket
+
+CLAMAV_TCP_PORT: "3310"
+CLAMAV_TCP_ADDR: "127.0.0.1"
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,17 @@
 ---
-# tasks file for ansible-clamav
+# Tasks file for ansible-clamav
 
 - name: "Include ubuntu tasks"
   include: "ubuntu.yml"
   static: "no"
   when:
-    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_release == "xenial"
+
+- name: "Include ubuntu 14 tasks"
+  include: "ubuntu14.yml"
+  static: "no"
+  when:
+    - ansible_distribution_release == "trusty"
 
 - name: "Include RedHat/CentOS tasks"
   include: "redhat.yml"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -27,6 +27,25 @@
     - "clamav-scanner-systemd"
     - "clamav-server-systemd"
 
+# If CLAMAV_SOCKET_TYPE is not defined, use tcp option
+- set_fact:
+    CLAMAV_SOCKET_TYPE: "tcp"
+  when:  CLAMAV_SOCKET_TYPE is not defined
+
+- name: "SELinux enable antivirus_can_scan_system"
+  seboolean:
+    name: antivirus_can_scan_system
+    state: yes
+    persistent: yes
+  when: ansible_selinux.status == "enabled"
+
+- name: "SELinux enable clamd_use_jit"
+  seboolean:
+    name: clamd_use_jit
+    state: yes
+    persistent: yes
+  when: ansible_selinux.status == "enabled"
+
 - name: "Config /etc/freshclam.conf from template"
   template:
     src: "etc/freshclam.conf.j2"
@@ -54,9 +73,17 @@
     dest: "/etc/clamd.conf"
     state: "link"
 
-- name: "Enable and start services"
+- name: "Create tmpfiles custom socket directory"
+  shell: "echo 'd /var/run/clamav 0755 clamscan clamscan' > /etc/tmpfiles.d/clamd.scam.archivematica.conf"
+  when: CLAMAV_SOCKET_TYPE ==  'file'
+
+- name: "Run systemd-tmpfiles to create custom socket directory"
+  shell: "systemd-tmpfiles --create /etc/tmpfiles.d/clamd.scam.archivematica.conf"
+  when: CLAMAV_SOCKET_TYPE ==  'file'
+
+- name: "Enable and restart services"
   service:
     name: "clamd@scan"
-    state: "started"
+    state: "restarted"
     enabled: "yes"
 

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -7,6 +7,68 @@
   with_items: 
     - "git"
 
+- name: "Check if clamav-daemon package was installed"
+  shell: dpkg-query -s clamav-daemon | grep -Eq "install ok installed"
+  register: dpkg_check_clamav_daemon
+  check_mode: no
+  ignore_errors: yes
+  changed_when: no
+
+# If CLAMAV_SOCKET_TYPE is not defined, use file option
+- set_fact:
+    CLAMAV_SOCKET_TYPE: "file"
+  when:  CLAMAV_SOCKET_TYPE is not defined
+
+- set_fact:
+    clamav_daemon_already_installed: true
+  when:  dpkg_check_clamav_daemon.rc == 0
+
+# Clamav-daemon already installed block
+- block:
+
+   # Check if clamav is running with file or tcp socket
+   - name: "Check if clamav was installed with file or tcp socket"
+     command: grep -Eq "^LocalSocket\ " /etc/clamav/clamd.conf
+     register: clamavunixsocket
+     check_mode: no
+     ignore_errors: yes
+     changed_when: no
+
+   - set_fact:
+       clamav_uses_file_socket: true
+     when: clamavunixsocket is defined and ( clamavunixsocket.rc == 0 )
+
+   # Purge clamav-daemon if was installed and socket type will change
+   - name: "Purge clamav-daemon"
+     apt:
+       name: clamav-daemon
+       purge: yes
+       state: absent
+       force: yes
+     when: 
+       - clamav_daemon_already_installed is defined
+       - CLAMAV_SOCKET_TYPE !=  'tcp' and clamav_uses_file_socket is not defined or clamav_daemon_already_installed is defined and CLAMAV_SOCKET_TYPE == 'tcp' and clamav_uses_file_socket is defined
+  when: clamav_daemon_already_installed is defined
+
+# Set debconf when installing clamav-daemon
+- name: "Configure debconf to use the tcp socket"
+  shell: "{{ item }}"
+  with_items:
+    - "echo 'clamav-daemon clamav-daemon/TcpOrLocal select TCP' | debconf-set-selections"
+    - "echo 'clamav-daemon clamav-daemon/TcpOrLocal seen' | debconf-set-selections"
+    - "echo 'clamav-daemon clamav-daemon/TCPAddr string {{ CLAMAV_TCP_ADDR }}' | debconf-set-selections"
+    - "echo 'clamav-daemon clamav-daemon/TCPAddr seen' | debconf-set-selections"
+    - "echo 'clamav-daemon clamav-daemon/TCPSocket string {{ CLAMAV_TCP_PORT }}' | debconf-set-selections"
+    - "echo 'clamav-daemon clamav-daemon/TCPSocket seen' | debconf-set-selections"
+  when: CLAMAV_SOCKET_TYPE == 'tcp'
+
+- name: "Configure debconf to use the unix socket"
+  shell: "{{ item }}"
+  with_items:
+    - "echo 'clamav-daemon clamav-daemon/TcpOrLocal select UNIX' | debconf-set-selections"
+    - "echo 'clamav-daemon clamav-daemon/TcpOrLocal seen' | debconf-set-selections"
+  when: CLAMAV_SOCKET_TYPE != 'tcp'
+
 - name: "Install clamav packages (Ubuntu)"
   apt:
     name: "{{ item }}"
@@ -39,7 +101,7 @@
 - name: "Enable services"
   service:
     name: "{{ item }}"
-    state: "started"
+    state: "restarted"
     enabled: "yes"
   with_items:
     - "clamav-daemon"

--- a/tasks/ubuntu14.yml
+++ b/tasks/ubuntu14.yml
@@ -1,0 +1,94 @@
+---
+
+- name: "Install packages required by role (Ubuntu14)"
+  apt:
+    name: "{{ item }}"
+    state: "latest"
+  with_items: 
+    - "git"
+
+- name: "Install clamav packages (Ubuntu14)"
+  apt:
+    name: "{{ item }}"
+    state: "latest"
+  with_items: 
+    - "clamav"
+    - "clamav-daemon"
+
+# If CLAMAV_SOCKET_TYPE is not defined, use file option
+- set_fact:
+    CLAMAV_SOCKET_TYPE: "file"
+  when:  CLAMAV_SOCKET_TYPE is not defined
+
+- name: "Configure clamav socket (tcp 1/3)"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^LocalSocket\ /var/run/clamav/clamd.ctl"
+     line: "#LocalSocket\ /var/run/clamav/clamd.ctl"
+  when: CLAMAV_SOCKET_TYPE ==  'tcp'
+
+- name: "Configure clamav socket (file 1/3)"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^#LocalSocket\ /var/run/clamav/clamd.ctl"
+     line: "LocalSocket\ /var/run/clamav/clamd.ctl"
+  when: CLAMAV_SOCKET_TYPE !=  'tcp'
+
+- name: "Configure clamav socket (tcp 2/3)"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^TCPSocket\ "
+     line: "TCPSocket\ {{ CLAMAV_TCP_PORT }}"
+     state: present
+  when: CLAMAV_SOCKET_TYPE ==  'tcp'
+
+- name: "Configure clamav socket (file 2/3)"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^TCPSocket\ "
+     state: absent
+  when: CLAMAV_SOCKET_TYPE !=  'tcp'
+
+- name: "Configure clamav socket (tcp 3/3)"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^TCPAddr\ "
+     line: "TCPAddr\ {{ CLAMAV_TCP_ADDR }}"
+     state: present
+  when: CLAMAV_SOCKET_TYPE ==  'tcp'
+
+- name: "Configure clamav socket (file 3/3)"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^TCPAddr\ "
+     state: absent
+  when: CLAMAV_SOCKET_TYPE !=  'tcp'
+
+- name: "Configure clamav MaxFileSize"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^MaxFileSize "
+     line: "MaxFileSize {{ CLAMAV_MAX_FILE_SIZE }}"
+
+- name: "Configure clamav StreamMaxLength"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^StreamMaxLength "
+     line: "StreamMaxLength {{ CLAMAV_MAX_STREAM_LENGTH }}"
+
+- name: "Configure clamav MaxScanSize"
+  lineinfile:
+     path: "/etc/clamav/clamd.conf"
+     regexp: "^MaxScanSize "
+     line: "MaxScanSize {{ CLAMAV_MAX_SCAN_SIZE }}"
+
+- name: "Include download-sigs.yml"
+  include: "download-sigs.yml"
+
+- name: "Enable services"
+  service:
+    name: "{{ item }}"
+    state: "restarted"
+    enabled: "yes"
+  with_items:
+    - "clamav-daemon"

--- a/templates/etc/clamd.d/scan.conf.j2
+++ b/templates/etc/clamd.d/scan.conf.j2
@@ -83,7 +83,12 @@ LogSyslog yes
 
 # Path to a local socket file the daemon will listen on.
 # Default: disabled (must be specified by a user)
+
+{% if CLAMAV_SOCKET_TYPE == 'file' %}
+LocalSocket /var/run/clamav/clamd.ctl
+{% else %}
 #LocalSocket /var/run/clamd.scan/clamd.sock
+{% endif %}
 
 # Sets the group ownership on the unix socket.
 # Default: disabled (the primary group of the user running clamd)
@@ -99,7 +104,11 @@ LogSyslog yes
 
 # TCP port address.
 # Default: no
-TCPSocket 3310
+{% if CLAMAV_SOCKET_TYPE == 'file' %}
+#TCPSocket 3310
+{% else %}
+TCPSocket {{ CLAMAV_TCP_PORT }}
+{% endif %}
 
 # TCP address.
 # By default we bind to INADDR_ANY, probably not wise.
@@ -107,7 +116,11 @@ TCPSocket 3310
 # from the outside world. This option can be specified multiple
 # times if you want to listen on multiple IPs. IPv6 is now supported.
 # Default: no
-TCPAddr 127.0.0.1
+{% if CLAMAV_SOCKET_TYPE == 'file' %}
+#TCPAddr 127.0.0.1
+{% else %}
+TCPAddr {{ CLAMAV_TCP_ADDR }}
+{% endif %}
 
 # Maximum length the queue of pending connections may grow to.
 # Default: 200

--- a/travis/Dockerfile.centos-7
+++ b/travis/Dockerfile.centos-7
@@ -1,0 +1,24 @@
+FROM centos:7
+
+# Install systemd -- See https://hub.docker.com/_/centos/
+RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
+RUN yum -y update; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*; \
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN yum -y install epel-release
+RUN yum -y install git ansible sudo
+
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/usr/sbin/init"]

--- a/travis/Dockerfile.ubuntu-trusty
+++ b/travis/Dockerfile.ubuntu-trusty
@@ -1,0 +1,12 @@
+FROM ubuntu:trusty
+
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-properties-common && rm -rf /var/lib/apt/lists/*
+
+RUN apt-add-repository -y ppa:ansible/ansible && apt-get update && apt-get install -y \
+    git \
+    ansible \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]

--- a/travis/Dockerfile.ubuntu-xenial
+++ b/travis/Dockerfile.ubuntu-xenial
@@ -1,0 +1,12 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y software-properties-common && rm -rf /var/lib/apt/lists/*
+
+RUN apt-add-repository -y ppa:ansible/ansible && apt-get update && apt-get install -y \
+    git \
+    ansible \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]

--- a/travis/test.yml
+++ b/travis/test.yml
@@ -1,0 +1,29 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - name: Ensure build dependencies are installed (RedHat)
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - "@Development tools"
+        - tar
+        - unzip
+        - sudo
+        - which
+      when: ansible_os_family == 'RedHat'
+
+    - name: Ensure build dependencies are installed (Debian)
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - build-essential
+        - unzip
+        - tar
+        - sudo
+      when: ansible_os_family == 'Debian'
+
+  roles:
+    - clamav_role


### PR DESCRIPTION
A new variable `CLAMAV_SOCKET_TYPE` has been added. It can take two
values: "tcp" or "file".

On CentOS and Ubuntu 14 it is configured in the `clamd.conf` file.

On Ubuntu 16 this configuration is more complex because the
clamav-daemon package uses three systemd files to configure the socket
type (unix file or tcp socket). This PR uses debconf-set-selections to
configure the socket type, but the clamav-daemon package doesn't read
the debconf system when upgrading or reinstalling, it is used only when
installing from scratch, so a package purge is needed when changing the
socket type.

The SELinux policies `antivirus_can_scan_system` and `clamd_use_jit` will
be activated if SELinux is enabled on CentOS.

On Ubuntu task files, the "Enable services" task has been modified to
restart the clamav-daemon service instead of starting. It is needed to
apply the changes made by the role.

On Ubuntu the default socket type is UNIX file.
On Centos the default socket type is TCP.

Finally, 2 additional variables have been added to define the TCP port and IP address to listen on:

- CLAMAV_TCP_ADDR: Default 127.0.0.1
- CLAMAV_TCP_PORT: Default 3310

It Fixes #5 
