### PR TITLE
CentOS: Add libsemanage-python osdep

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -10,6 +10,7 @@
     state: "latest"
   with_items: 
     - "git"
+    - "libsemanage-python"
 
 - name: "Install required packages (RedHat)"
   yum:


### PR DESCRIPTION
This commit adds the missing libsemanage-python package dependency.

Connected to https://github.com/archivematica/Issues/issues/454