### PR TITLE
Remove clamav-server  package

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -13,8 +13,7 @@
 - name: "Install required packages (RedHat)"
   yum:
     name: ['clamav', 'clamav-data', 'clamav-devel', 'clamav-filesystem',
-           'clamav-lib', 'clamav-server', 'clamav-scanner', 'clamav-update',
-           'clamav-scanner-systemd', 'clamav-server-systemd']
+           'clamav-lib', 'clamd', 'clamav-update' ]
     state: "latest"
 
 # If CLAMAV_SOCKET_TYPE is not defined, use tcp option


### PR DESCRIPTION
Some packages were needed for the transition to systemd, but they aren't
available now.

Connects to https://github.com/archivematica/Issues/issues/1119